### PR TITLE
Customization options

### DIFF
--- a/water_torture.cpp
+++ b/water_torture.cpp
@@ -70,7 +70,7 @@ void Water_Torture::step() {
     
   } else if ( state == WT_SWELLING ) {
     ++position;
-    if (color.blue <= 10 || color.blue - position/2 <= 10) {
+    if (color.getLuma() <= 10 || color.getLuma() - position/2 <= 10) {
       state = WT_FALLING;
       position = 0;
     }  
@@ -140,8 +140,8 @@ void Water_Torture::animate() {
     if (!is_active()) {
       // Create a new droplet
 
-      // Note: Hardcoded to Blue here.
-      color = CRGB::Blue;
+      // Reset to original base color.
+      color = base_color;
       droplet_pause = 200 + random16() % 500;
       state = (random8() < 96) ? WT_SWELLING : WT_FALLING;
       // reset positon & speed for new droplet
@@ -168,15 +168,32 @@ uint8_t Water_Torture::getState() {
     return state;
 }
 
+int16_t Water_Torture::getSpeed() {
+    return speed;
+}
+
+uint16_t Water_Torture::getGravity() {
+    return gravity;
+}
+
 /**
  * Setters
  */
-void Water_Torture::setColor(uint32_t newColor) {
-    color = newColor;
+void Water_Torture::setColor(CRGB newColor) {
+    base_color = newColor;
+    color = base_color;
 }
 
-void Water_Torture::setState(uint8_t newState) {
+void Water_Torture::setState(States newState) {
     state = newState;
+}
+
+void Water_Torture::setSpeed(int16_t newspeed) {
+  speed = newspeed;
+}
+
+void Water_Torture::setGravity(uint16_t newgravity) {
+  gravity = newgravity;
 }
 
 void Water_Torture::setFastled(CLEDController* fled) {

--- a/water_torture.h
+++ b/water_torture.h
@@ -34,9 +34,13 @@ class Water_Torture {
     // getters/setters
     uint32_t getColor();
     uint8_t getState();
+    int16_t getSpeed();
+    uint16_t getGravity();
 
-    void setColor(uint32_t);
-    void setState(uint8_t);
+    void setColor(CRGB);
+    void setState(States);
+    void setSpeed(int16_t);
+    void setGravity(uint16_t);
     void setFastled(CLEDController*);
     void setLeds(CRGB*);
 
@@ -62,10 +66,11 @@ class Water_Torture {
 
     uint16_t position = 0;
     int16_t speed = 0;
-    static const uint16_t gravity = 8;
+    uint16_t gravity = 8;
     uint16_t NumLeds;
     uint8_t maxpos;
     
+    CRGB base_color = CRGB::Blue;
     CRGB color = CRGB::Blue;
     CRGB *leds;
     CLEDController *fastled;

--- a/water_torture_fled.ino
+++ b/water_torture_fled.ino
@@ -24,15 +24,16 @@ CLEDController *fled_ptr; // Pointer to FastLED instance
 #include "water_torture.h"
 
 Water_Torture droplet = Water_Torture();
-//Water_Torture droplet2 = Water_Torture();
+Water_Torture droplet2 = Water_Torture();
 
 void setup() {
-    fled_ptr = &(FastLED.addLeds<WS2811,DATA_PIN,RGB>(leds, NUM_LEDS));
+    fled_ptr = &(FastLED.addLeds<WS2811,DATA_PIN,GRB>(leds, NUM_LEDS));
     FastLED.setBrightness(255);
     droplet.setFastled(fled_ptr);
-    //droplet2.setFastled(fled_ptr);
-    //droplet2.setColor(CRGB::Orange);
-    //droplet2.droplet_pause = 750;
+    droplet2.setFastled(fled_ptr);
+    droplet2.setColor(CRGB::Orange);
+    droplet2.setGravity(5);
+    droplet2.droplet_pause = 750;
 
     /* Uncomment `test()` method in Water_Torture to use */
     //droplet.test();
@@ -43,7 +44,7 @@ void setup() {
 
 void loop() {
   droplet.animate();
-  //droplet2.animate();
+  droplet2.animate();
 }
 
 // - fin -


### PR DESCRIPTION
* You can now set a base color for the droplet.
* State change from `swelling` to `falling` now uses luma instead of the intensity of the `blue` component of the current color value.
* New `setGravity()` method to change the acceleration.
* Demo file running two droplets simultaneously by default now, to show the new features.