### PR TITLE
Add support to reverse direction of droplet

### DIFF
--- a/water_torture.h
+++ b/water_torture.h
@@ -11,7 +11,7 @@
  * @license BSL 1.0
  */
 
-#define WATERTORTURE_VERSION "1.1.0"
+#define WATERTORTURE_VERSION "1.2.0"
 /**
  * The various states for our state machnine, which is handled in our `step()`
  * and `draw()` methods. See the diagram in `Water_Torture.cpp`.
@@ -35,12 +35,14 @@ class Water_Torture {
     uint32_t getColor();
     uint8_t getState();
     int16_t getSpeed();
-    uint16_t getGravity();
+    int16_t getGravity();
+    bool getReverse();
 
     void setColor(CRGB);
     void setState(States);
     void setSpeed(int16_t);
-    void setGravity(uint16_t);
+    void setGravity(int16_t);
+    void setReverse(bool);
     void setFastled(CLEDController*);
     void setLeds(CRGB*);
 
@@ -52,8 +54,6 @@ class Water_Torture {
     bool is_active(void) const;
     uint16_t droplet_pause;
 
-    //void test(void);
-
   private:
     static uint8_t add_clipped(uint16_t, uint16_t);
     static void add_clipped_to(CRGB*, CRGB);
@@ -61,14 +61,14 @@ class Water_Torture {
     static CRGB scale(CRGB, uint16_t);
     
     States state = WT_SWELLING;
-    bool allow_swelling = true;
     static const uint16_t collision_scaling = 40;
 
     uint16_t position = 0;
     int16_t speed = 0;
-    uint16_t gravity = 8;
+    int16_t gravity = 8;
     uint16_t NumLeds;
     uint8_t maxpos;
+    bool reverse_dir = false;
     
     CRGB base_color = CRGB::Blue;
     CRGB color = CRGB::Blue;

--- a/water_torture_fled.ino
+++ b/water_torture_fled.ino
@@ -24,21 +24,26 @@ CLEDController *fled_ptr; // Pointer to FastLED instance
 #include "water_torture.h"
 
 Water_Torture droplet = Water_Torture();
+// add a second droplet
 Water_Torture droplet2 = Water_Torture();
 
 void setup() {
     fled_ptr = &(FastLED.addLeds<WS2811,DATA_PIN,GRB>(leds, NUM_LEDS));
     FastLED.setBrightness(255);
     droplet.setFastled(fled_ptr);
-    droplet2.setFastled(fled_ptr);
-    droplet2.setColor(CRGB::Orange);
-    droplet2.setGravity(5);
-    droplet2.droplet_pause = 750;
 
-    /* Uncomment `test()` method in Water_Torture to use */
-    //droplet.test();
-    //FastLED.delay(2000);
-    
+    // Configure 2nd droplet
+    droplet2.setFastled(fled_ptr);
+    // Configurable color!
+    droplet2.setColor(CRGB::Orange);
+    // Configurable gravity!
+    droplet2.setGravity(4);
+    // Set the initial pause (milliseconds)
+    droplet2.droplet_pause = 750;
+    // Start from the far end of the strip, in case your
+    // setup runs from bottom to top:
+    droplet2.setReverse(true);
+
     FastLED.clear();
 }
 


### PR DESCRIPTION
* Use `.setReverse(true)` to reverse direction of a droplet.
* Removed `test()` method.
* Updated sample sketch to demo reverse direction.